### PR TITLE
Several commits from the copy I use locally

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version 2.5
 	- Added server OS detection and installed server features processing
 	- Add patch found in registry scan to patches array
 	- Remove obsolete "Q" patch detection
+	- Support x86_64 versions of Windows (registry sofware discovery)
 
 Version 2.4
 	- Fixed bug for drive names in while generating XML files

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,8 @@ Version 2.5
 	- Extended OS Identifcation to include Windows 10 build number
 	- Send build number only to xml output (for parser)
 	- Added server OS detection and installed server features processing
+	- Add patch found in registry scan to patches array
+	- Remove obsolete "Q" patch detection
 
 Version 2.4
 	- Fixed bug for drive names in while generating XML files

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 2.5
 	- Added Greek language file for ss-xml2word.vbs (by Manos Petridis)
+	- Force use of cscript, if wscript is calling shell, rerun via cscript
 
 Version 2.4
 	- Fixed bug for drive names in while generating XML files

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 Version 2.5
 	- Added Greek language file for ss-xml2word.vbs (by Manos Petridis)
 	- Force use of cscript, if wscript is calling shell, rerun via cscript
-
+	- Added GetKBNumber(), GetRegHFID(), and GetRegUpdateType() functions
+	  for use by GatherRegInformation() update processing.
 Version 2.4
 	- Fixed bug for drive names in while generating XML files
 	- Fixed character bug in SYDI-Server which impacted SYDI-Overview

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Version 2.5
 	- Force use of cscript, if wscript is calling shell, rerun via cscript
 	- Added GetKBNumber(), GetRegHFID(), and GetRegUpdateType() functions
 	  for use by GatherRegInformation() update processing.
+	- Extended OS Identifcation to include Windows 10 build number
+	- Send build number only to xml output (for parser)
+	- Added server OS detection and installed server features processing
+
 Version 2.4
 	- Fixed bug for drive names in while generating XML files
 	- Fixed character bug in SYDI-Server which impacted SYDI-Overview

--- a/sydi-server.vbs
+++ b/sydi-server.vbs
@@ -51,6 +51,20 @@ Option Explicit
 ' POSSIBILITY OF SUCH DAMAGE.
 '==========================================================
 '==========================================================
+' Force to run in cscript, if run from wscript, rerun from cscript with args
+Sub forceCScriptExecution
+	Dim Arg, Str
+	If Not LCase( Right( WScript.FullName, 12 ) ) = "\cscript.exe" Then
+		For Each Arg In WScript.Arguments
+			If InStr( Arg, " " ) Then Arg = """" & Arg & """"
+			Str = Str & " " & Arg
+		Next
+		CreateObject( "WScript.Shell" ).Run "cscript //nologo """ & WScript.ScriptFullName & """ " & Str
+		WScript.Quit
+	End If
+End Sub
+forceCScriptExecution
+
 ' Settings
 Dim strDocumentAuthor, strComputer
 

--- a/sydi-server.vbs
+++ b/sydi-server.vbs
@@ -117,6 +117,9 @@ Dim strTotalPhysicalMemoryMB, strDomainType, strComputerRole
 ' Variables for the Win32_ComputerSystemProduct class
 Dim strComputerSystemProduct_Manufacturer, strComputerSystemProduct_Name, strComputerSystemProduct_IdentifyingNumber
 
+'Variable for the Win32_ServerFeature class
+Dim objDbrServerFeatures
+
 ' Variables For the Win32_DiskDrive, Win32_DiskPartition and Win32_LogicalDisk classes
 Dim objDbrDrives, objDbrDisks, objDiskPartitions, objDiskPartition, objLogicalDisks, objLogicalDisk
 
@@ -708,7 +711,7 @@ Function GatherWMIInformation()
 
 
 	ReportProgress " Gathering OS information"
-	Set colItems = objWMIService.ExecQuery("Select Name, CSDVersion, InstallDate, OSLanguage, Version, WindowsDirectory from Win32_OperatingSystem",,48)
+	Set colItems = objWMIService.ExecQuery("Select Name, BuildNumber, CSDVersion, InstallDate, OSLanguage, Version, WindowsDirectory from Win32_OperatingSystem",,48)
 	For Each objItem in colItems
 		strOperatingSystem_InstallDate = objItem.InstallDate
 		strOperatingSystem_Build = objItem.BuildNumber

--- a/sydi-server.vbs
+++ b/sydi-server.vbs
@@ -485,6 +485,31 @@ Function GatherIISInformation()
 	ReportProgress "End subroutine: GatherIISInformation(" & strComputer & ")"
 End Function ' GatherIISInformation()
 
+Function GetKBNumber(strKBID)
+	Dim arrSplitKB
+	arrSplitKB = Split(strKBID, "B")
+	GetKBNumber = arrSplitKB(1)
+End Function
+
+Function GetRegHFID(strRegProgramsDisplayName)
+	Dim arrSplitDN1, arrSplitDN2
+	arrSplitDN1 = Split(strRegProgramsDisplayName, "(")
+	arrSplitDN2 = Split(arrSplitDN1(1), ")")
+	GetRegHFID = arrSplitDN2(0)
+End Function
+
+Function GetRegUpdateType(strRegProgramsDisplayName)
+	Dim arrSplitName
+	arrSplitName = split(strRegProgramsDisplayName)
+	If ( arrSplitName(0) = "Security" ) Then
+		GetRegUpdateType = "Security Update"
+	Elseif ( arrSplitName(0) = "Service" ) Then
+		GetRegUpdateType = "Service Pack"
+	Else
+		GetRegUpdateType = "Update"
+	End If
+End Function
+
 Function GatherRegInformation()
 	Dim arrRegValueNames, arrRegValueTypes
 	Dim dwValue

--- a/sydi-server.vbs
+++ b/sydi-server.vbs
@@ -244,6 +244,7 @@ Dim strStylesheet, strXSLFreeText
 
 ' Constants
 Const adVarChar = 200
+Const adVarWChar = 202
 Const MaxCharacters = 255
 
 '==========================================================
@@ -1026,7 +1027,7 @@ Function GatherWMIInformation()
 		ReportProgress " Gathering application information"
 		Set colItems = objWMIService.ExecQuery("Select Name, Vendor, Version, InstallDate from Win32_Product WHERE Name <> Null",,48)
 		Set objDbrProducts = CreateObject("ADOR.Recordset")
-		objDbrProducts.Fields.Append "ProductName", adVarChar, MaxCharacters
+		objDbrProducts.Fields.Append "ProductName", adVarWChar, MaxCharacters
 		objDbrProducts.Fields.Append "Vendor", adVarChar, MaxCharacters
 		objDbrProducts.Fields.Append "Version", adVarChar, MaxCharacters
 		objDbrProducts.Fields.Append "InstallDate", adVarChar, MaxCharacters

--- a/xml/serverhtml.xsl
+++ b/xml/serverhtml.xsl
@@ -283,6 +283,25 @@ The system has <xsl:value-of select = "computer/processor/@count" /> processor(s
 </xsl:for-each>
 </xsl:if>
 
+<xsl:if test="computer/server_features/feature">
+<br />
+<strong>Server Features</strong><br />
+<table>
+	<tr>
+		<th>Parent ID</th>
+		<th>ID</th>
+		<th>Name</th>
+	</tr>
+	<xsl:for-each select ="/computer/server_features/feature" >
+		<tr>
+			<td><xsl:value-of select = "@parentid"/></td>
+			<td><xsl:value-of select = "@id"/></td>
+			<td><xsl:value-of select = "@name"/></td>
+		</tr>
+	</xsl:for-each> 
+</table>
+</xsl:if>
+
 <xsl:if test="computer/patches/patch">
 <h2 id="softwareplatform_patches">Installed Patches</h2>
 <table>


### PR DESCRIPTION
From changelog.txt
- Force use of cscript, if wscript is calling shell, rerun via cscript
- Added GetKBNumber(), GetRegHFID(), and GetRegUpdateType() functions
  for use by GatherRegInformation() update processing.
- Extended OS Identifcation to include Windows 10 build number
- Send build number only to xml output (for parser)
- Added server OS detection and installed server features processing
- Add patch found in registry scan to patches array
- Remove obsolete "Q" patch detection
- Support x86_64 versions of Windows (registry sofware discovery)
